### PR TITLE
Clarify the need to import the class or use the facade in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ If you're using Laravel 5.5 or later you can start using the package at this poi
 Anywhere in your code you can create a new action like so:
 
 ```php
+use TorMorten\Eventy\Facades\Events as Eventy;
+
 Eventy::action('my.hook', 'awesome');
 ```
 


### PR DESCRIPTION
The documentation is a bit confusing in that the examples can't be used as-is. You need to take the example and then either add a backslash to `Eventy::{method}` to use the `Eventy` facade, or import the `Events` facade as `Eventy`.

That may be obvious to a seasoned Laravel user, but it wasn't to me, so after I figured out what I was doing wrong, I updated the readme to make this a bit more clear. This should help to reduce issues like #15.